### PR TITLE
New AFK command runs via /AFK

### DIFF
--- a/commands/afk.ts
+++ b/commands/afk.ts
@@ -1,44 +1,42 @@
 import { CommandInterface } from "./CommandInterface";
-import { CommandInteraction, SlashCommandBuilder, RESTJSONErrorCodes, } from "discord.js";
+import {
+  CommandInteraction,
+  SlashCommandBuilder,
+  RESTJSONErrorCodes,
+} from "discord.js";
 import axios from "axios";
-
 
 module.exports = {
   data: new SlashCommandBuilder()
     .setName("afk")
-    .setDescription("Appends -AFK to users nickname (Or un-appends depending if you're already AFK!)"),
-  async execute(interaction) {
-    const usernameOfMember = interaction.user.username;
-    const nicknameOfMember = interaction.member.nickname;
-    if (nicknameOfMember != null && nicknameOfMember.includes(" - AFK")) {
-      await interaction.member.setNickname(usernameOfMember);
+    .setDescription(
+      "Appends -AFK to users nickname (Or un-appends depending if you're already AFK!)"
+    ),
+  async execute(interaction: CommandInteraction) {
+    const afkAppend = "- AFK";
+    const currName: string =
+      interaction.member.nickname || interaction.user.username;
+    if (currName.endsWith(afkAppend)) {
+      await interaction.member.setNickname(currName.replace(afkAppend, ""));
       return interaction.reply({
         content: `You are no longer AFK`,
         ephemeral: true,
       });
-    } else if (nicknameOfMember == null)
-      try {
-        await interaction.member.setNickname(
-          interaction.user.username + " - AFK"
-        );
+    }
+    try {
+      await interaction.member.setNickname(`${currName} ${afkAppend}`);
+      return interaction.reply({
+        content: `You have now been set to AFK`,
+        ephemeral: true,
+      });
+    } catch (error) {
+      if (error.code === RESTJSONErrorCodes.MissingPermissions) {
         return interaction.reply({
-          content: `You have now been set to AFK`,
+          content: `Unfortunately the bot does not have the permission to change your nickname, this is most likely due to you being the server owner!`,
           ephemeral: true,
         });
-      } catch (error) {
-        if (error.code === RESTJSONErrorCodes.MissingPermissions) {
-          return interaction.reply({
-            content: `Unfortunately the bot does not have the permission to change your nickname, this is most likely due to you being the server owner!`,
-            ephemeral: true,
-          });
-        } else {
-          console.log(error);
-        }
       }
+      console.log(error);
+    }
   },
 };
-
-
-
-
-

--- a/commands/afk.ts
+++ b/commands/afk.ts
@@ -1,0 +1,44 @@
+import { CommandInterface } from "./CommandInterface";
+import { CommandInteraction, SlashCommandBuilder, RESTJSONErrorCodes, } from "discord.js";
+import axios from "axios";
+
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName("afk")
+    .setDescription("Appends -AFK to users nickname (Or un-appends depending if you're already AFK!)"),
+  async execute(interaction) {
+    const usernameOfMember = interaction.user.username;
+    const nicknameOfMember = interaction.member.nickname;
+    if (nicknameOfMember != null && nicknameOfMember.includes(" - AFK")) {
+      await interaction.member.setNickname(usernameOfMember);
+      return interaction.reply({
+        content: `You are no longer AFK`,
+        ephemeral: true,
+      });
+    } else if (nicknameOfMember == null)
+      try {
+        await interaction.member.setNickname(
+          interaction.user.username + " - AFK"
+        );
+        return interaction.reply({
+          content: `You have now been set to AFK`,
+          ephemeral: true,
+        });
+      } catch (error) {
+        if (error.code === RESTJSONErrorCodes.MissingPermissions) {
+          return interaction.reply({
+            content: `Unfortunately the bot does not have the permission to change your nickname, this is most likely due to you being the server owner!`,
+            ephemeral: true,
+          });
+        } else {
+          console.log(error);
+        }
+      }
+  },
+};
+
+
+
+
+

--- a/discord.d.ts
+++ b/discord.d.ts
@@ -4,4 +4,9 @@ declare module "discord.js" {
     export interface Client {
       commands: Collection<unknown, any>
     }
+
+    export interface APIInteractionGuildMember {
+      nickname: string;
+      setNickname: (nick: string) => void
+    }
   }


### PR DESCRIPTION
A newly built command that appends " - AFK" onto a the nickname of a discord user, can also remove " - AFK" when ran again. 